### PR TITLE
Fixed text cut-off when sending some short messages

### DIFF
--- a/UI/Code/Presenters/Message Item/Message Types/Medium/Primitives/LYRUITextMessageContentViewPresenter.m
+++ b/UI/Code/Presenters/Message Item/Message Types/Medium/Primitives/LYRUITextMessageContentViewPresenter.m
@@ -97,7 +97,8 @@ static CGFloat const LYRUITextMessageContentViewVerticalPadding = 17.0;
     [textStorage addAttributes:textView.typingAttributes range:NSMakeRange(0, [textStorage length])];
     [textContainer setLineFragmentPadding:textView.textContainer.lineFragmentPadding];
     [layoutManager glyphRangeForTextContainer:textContainer];
-    return [layoutManager usedRectForTextContainer:textContainer].size.height + LYRUITextMessageContentViewVerticalPadding;
+    CGFloat textContainerHeight = ceil([layoutManager usedRectForTextContainer:textContainer].size.height);
+    return textContainerHeight + LYRUITextMessageContentViewVerticalPadding;
 }
 
 #pragma mark - UITextViewDelegate


### PR DESCRIPTION
Using ceil function to fix issue on iPhone 8/8 Plus screen size devices.